### PR TITLE
Panic assertion

### DIFF
--- a/equality.go
+++ b/equality.go
@@ -17,7 +17,7 @@ func Contains[T ~string, K ~string](t *testing.T, data T, substring K) {
 	}
 }
 
-// Equals checks if the values are equal (deeply).
+// Equals checks if the values are equal (deeply)
 func Equals[T any](t *testing.T, got T, expected T) {
 	t.Helper()
 	if !reflect.DeepEqual(expected, got) {

--- a/equality.go
+++ b/equality.go
@@ -17,7 +17,7 @@ func Contains[T ~string, K ~string](t *testing.T, data T, substring K) {
 	}
 }
 
-// Equals checks if the values are equal (deeply)
+// Equals checks if the values are equal (deeply).
 func Equals[T any](t *testing.T, got T, expected T) {
 	t.Helper()
 	if !reflect.DeepEqual(expected, got) {

--- a/panic.go
+++ b/panic.go
@@ -1,0 +1,29 @@
+package assert
+
+import "testing"
+
+// Panics asserts that the function causes a panic.
+func Panics(t *testing.T, functionToTest func()) {
+	defer func() {
+		// This defered function will recover it if it panics
+		if r := recover(); r == nil {
+			t.Fatalf("Expected function to panic, but it didn't.")
+		}
+	}()
+
+	// Run function to see if it panics.
+	functionToTest()
+}
+
+// Panics asserts that the function causes a panic.
+func NoPanic(t *testing.T, functionToTest func()) {
+	defer func() {
+		// This defered function will recover it if it panics
+		if r := recover(); r != nil {
+			t.Fatalf("Expected function to not panic, but it did.")
+		}
+	}()
+
+	// Run function to see if it panics.
+	functionToTest()
+}

--- a/panic.go
+++ b/panic.go
@@ -20,7 +20,7 @@ func NoPanic(t *testing.T, functionToTest func()) {
 	defer func() {
 		// This defered function will recover it if it panics
 		if r := recover(); r != nil {
-			t.Fatalf("Expected function to not panic, but it did.")
+			t.Fatalf("Expected function to not panic, but it did. Panic output: %v", r)
 		}
 	}()
 

--- a/panic.go
+++ b/panic.go
@@ -15,7 +15,7 @@ func Panics(t *testing.T, functionToTest func()) {
 	functionToTest()
 }
 
-// Panics asserts that the function causes a panic.
+// NoPanic asserts that the function does not cause a panic.
 func NoPanic(t *testing.T, functionToTest func()) {
 	defer func() {
 		// This defered function will recover it if it panics

--- a/panic_test.go
+++ b/panic_test.go
@@ -1,0 +1,43 @@
+package assert_test
+
+import (
+	"testing"
+
+	"go.arcalot.io/assert"
+)
+
+func panicsTest() {
+	panic("This is for testing purposes")
+}
+
+func panicWithArgs(_ int, _ int) {
+	panic("This is for testing purposes")
+}
+
+func TestCatchesPanic(t *testing.T) {
+	// Does panic
+	assert.Panics(t, panicsTest)
+	assert.Panics(t, func() {
+		panicWithArgs(0, 0)
+	})
+	// Does not panic
+	testFailure(t, func(t *testing.T) {
+		assert.Panics(t, func() {})
+	})
+}
+
+func TestNoPanic(t *testing.T) {
+	// Does not panic
+	assert.NoPanic(t, func() {})
+
+	// Does panic
+	testFailure(t, func(t *testing.T) {
+		assert.NoPanic(t, panicsTest)
+	})
+	// Does panic
+	testFailure(t, func(t *testing.T) {
+		assert.NoPanic(t, func() {
+			panicWithArgs(0, 0)
+		})
+	})
+}


### PR DESCRIPTION
## Changes introduced with this PR

This PR, which is based on #10 (so make sure you only look at the changes in the "Added panic assertions" commit and the ones that follow), adds the ability to verify that functions do or do not panic. For functions that have more than zero args, just wrap them in anonymous functions.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).