### PR TITLE
Return features

### DIFF
--- a/error.go
+++ b/error.go
@@ -33,9 +33,9 @@ func Error(t *testing.T, err error) {
 }
 
 // ErrorR checks if there was an error provided.
-func ErrorR[T any](t *testing.T) func(T, error) {
+func ErrorR(t *testing.T) func(any, error) {
 	t.Helper()
-	return func(r T, err error) {
+	return func(r any, err error) {
 		t.Helper()
 		if err == nil {
 			t.Fatalf("No error returned")

--- a/error_test.go
+++ b/error_test.go
@@ -118,13 +118,13 @@ func TestErrorR(externalT *testing.T) {
 	go func() {
 		defer wg.Done()
 		// Should fail
-		assert.ErrorR[bool](&internalT1)(true, nil)
+		assert.ErrorR(&internalT1)(true, nil)
 	}()
 
 	go func() {
 		defer wg.Done()
 		// Should not fail
-		assert.ErrorR[bool](&internalT2)(true, errors.New("This is an error"))
+		assert.ErrorR(&internalT2)(true, errors.New("This is an error"))
 	}()
 
 	wg.Wait()

--- a/nil.go
+++ b/nil.go
@@ -22,3 +22,12 @@ func NotNil(t *testing.T, value any) {
 		t.Fatalf("Unexpected nil value")
 	}
 }
+
+// NotNilR asserts that the input is not nil, and returns it.
+func NotNilR[T any](t *testing.T, value T) T {
+	t.Helper()
+	if reflect.ValueOf(value).IsNil() {
+		t.Fatalf("Unexpected nil value")
+	}
+	return value
+}

--- a/panic.go
+++ b/panic.go
@@ -6,7 +6,7 @@ import "testing"
 // Does not detect panics in separate goroutines.
 func Panics(t *testing.T, functionToTest func()) {
 	defer func() {
-		// This defered function will recover it if it panics
+		// This deferred function will recover it if it panics
 		if r := recover(); r == nil {
 			t.Fatalf("Expected function to panic, but it didn't.")
 		}
@@ -20,7 +20,7 @@ func Panics(t *testing.T, functionToTest func()) {
 // Does not detect panics in separate goroutines.
 func NoPanic(t *testing.T, functionToTest func()) {
 	defer func() {
-		// This defered function will recover it if it panics
+		// This deferred function will recover it if it panics
 		if r := recover(); r != nil {
 			t.Fatalf("Expected function to not panic, but it did. Panic output: %v", r)
 		}


### PR DESCRIPTION
## Changes introduced with this PR

This adds a not nill returning assertion, and changes the type requirements for the errorR function. This should make it more easy to use.

The change to the type requirements may be a breaking change for code that uses it, but I do not think it's worth going to a new version for this one. It's a pain to do that in GoLang.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).