### PR TITLE
Added map key tests

### DIFF
--- a/map.go
+++ b/map.go
@@ -1,0 +1,47 @@
+package assert
+
+import (
+	"testing"
+)
+
+// MapContainsKeyAny asserts that the key is in the map, and returns the value if it passes.
+// For use with maps with any as the key type.
+func MapContainsKeyAny[V any](t *testing.T, key any, testedMap map[any]V) V {
+	t.Helper()
+	value, ok := testedMap[key]
+	if !ok {
+		t.Fatalf("Map does not contain key '%v'", key)
+	}
+	return value
+}
+
+// MapNotContainsKeyAny asserts that the key is not in the map.
+// For use with maps with any as the key type.
+func MapNotContainsKeyAny[V any](t *testing.T, key any, testedMap map[any]V) {
+	t.Helper()
+	_, ok := testedMap[key]
+	if ok {
+		t.Fatalf("Map contains key '%v'", key)
+	}
+}
+
+// MapContainsKey asserts that the key is in the map, and returns the value if it passes.
+// For maps that do not have any as their key type, and instead have a comparable type.
+func MapContainsKey[K comparable, V any](t *testing.T, key K, testedMap map[K]V) V {
+	t.Helper()
+	value, ok := testedMap[key]
+	if !ok {
+		t.Fatalf("Map does not contain key '%v'", key)
+	}
+	return value
+}
+
+// MapNotContainsKey asserts that the key is not in the map.
+// For maps that do not have any as their key type, and instead have a comparable type.
+func MapNotContainsKey[K comparable, V any](t *testing.T, key K, testedMap map[K]V) {
+	t.Helper()
+	_, ok := testedMap[key]
+	if ok {
+		t.Fatalf("Map contains key '%v'", key)
+	}
+}

--- a/map_test.go
+++ b/map_test.go
@@ -1,0 +1,60 @@
+package assert_test
+
+import (
+	"go.arcalot.io/assert"
+	"testing"
+)
+
+//nolint:dupl
+func TestMapContains(t *testing.T) {
+	input := map[string]int{"a": 1, "b": 2}
+	result := assert.MapContainsKey(t, "a", input)
+	assert.Equals(t, result, 1)
+	assert.MapNotContainsKey(t, "d", input)
+
+	testFailure(t, func(t *testing.T) {
+		assert.MapContainsKey(t, "z", input)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.MapNotContainsKey(t, "a", input)
+	})
+
+	input2 := map[int]string{1: "a", 2: "b"}
+	result2 := assert.MapContainsKey(t, 1, input2)
+	assert.Equals(t, result2, "a")
+	assert.MapNotContainsKey(t, 3, input2)
+
+	testFailure(t, func(t *testing.T) {
+		assert.MapContainsKey(t, 3, input2)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.MapNotContainsKey(t, 1, input2)
+	})
+}
+
+//nolint:dupl
+func TestMapContainsAny(t *testing.T) {
+	input := map[any]int{"a": 1, "b": 2}
+	result := assert.MapContainsKeyAny(t, "a", input)
+	assert.Equals(t, result, 1)
+	assert.MapNotContainsKeyAny(t, "d", input)
+
+	testFailure(t, func(t *testing.T) {
+		assert.MapContainsKeyAny(t, "z", input)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.MapNotContainsKeyAny(t, "a", input)
+	})
+
+	input2 := map[any]string{1: "a", 2: "b"}
+	result2 := assert.MapContainsKeyAny(t, 1, input2)
+	assert.Equals(t, result2, "a")
+	assert.MapNotContainsKeyAny(t, 3, input2)
+
+	testFailure(t, func(t *testing.T) {
+		assert.MapContainsKeyAny(t, 3, input2)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.MapNotContainsKeyAny(t, 1, input2)
+	})
+}


### PR DESCRIPTION
## Changes introduced with this PR

Added key contains tests.

I needed to do separate tests for any and non-any because any is not comparable. It's like a special case in Go.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).