### PR TITLE
Added slice assertions

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -1,0 +1,54 @@
+package assert
+
+import (
+	"reflect"
+	"testing"
+)
+
+// SliceContains asserts that the value is in the list. Returns the index. O log N runtime.
+func SliceContains[V any](t *testing.T, expected any, testedSlice []V) int {
+	t.Helper()
+	for i, value := range testedSlice {
+		if reflect.DeepEqual(value, expected) {
+			return i
+		}
+	}
+	t.Fatalf("Slice does not contain value '%v'", expected)
+	return -1
+}
+
+// SliceNotContains asserts that the value is not in the list. O log N runtime.
+func SliceNotContains[V any](t *testing.T, unexpectedValue any, testedSlice []V) {
+	t.Helper()
+	for _, value := range testedSlice {
+		if reflect.DeepEqual(value, unexpectedValue) {
+			t.Fatalf("Slice contains value '%v'", unexpectedValue)
+		}
+	}
+}
+
+// SliceContainsMatch checks each value with your test function.
+// The test function should take the type of one item in the list, and return true if the expected value is found.
+func SliceContainsMatch[V any](t *testing.T, testFunction func(V) bool, testedSlice []V) int {
+	t.Helper()
+	for i, value := range testedSlice {
+		if testFunction(value) {
+			return i
+		}
+	}
+	t.Fatalf("Slice does not contain a value that satisfies the given testFunction'")
+	return -1
+}
+
+// SliceContainsExtractor allows you to pass in a function to extract a value from the given type to compare.
+// Returns the index of the value.
+func SliceContainsExtractor[T any, V any](t *testing.T, valueExtractor func(T) V, expected V, testedSlice []T) int {
+	t.Helper()
+	for i, value := range testedSlice {
+		if reflect.DeepEqual(expected, valueExtractor(value)) {
+			return i
+		}
+	}
+	t.Fatalf("Slice does not contain an extracted value that matches the expected value '%v'.'", expected)
+	return -1
+}

--- a/slice_test.go
+++ b/slice_test.go
@@ -1,0 +1,149 @@
+package assert_test
+
+import (
+	"go.arcalot.io/assert"
+	"testing"
+)
+
+func TestSliceContainsInt(t *testing.T) {
+	input := []int{1, 2}
+	result := assert.SliceContains(t, 1, input)
+	assert.Equals(t, result, 0)
+	result = assert.SliceContains(t, 2, input)
+	assert.Equals(t, result, 1)
+
+	assert.SliceNotContains(t, 0, input)
+	assert.SliceNotContains(t, -10, input)
+	assert.SliceNotContains(t, 100, input)
+	assert.SliceNotContains(t, "a", input)
+
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContains(t, 0, input)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContains(t, "a", input)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.SliceNotContains(t, 1, input)
+	})
+}
+
+func TestSliceContainsStr(t *testing.T) {
+	input := []string{"a", "b"}
+	result := assert.SliceContains(t, "a", input)
+	assert.Equals(t, result, 0)
+	result = assert.SliceContains(t, "b", input)
+	assert.Equals(t, result, 1)
+
+	assert.SliceNotContains(t, 0, input)
+	assert.SliceNotContains(t, -10, input)
+	assert.SliceNotContains(t, 100, input)
+	assert.SliceNotContains(t, "", input)
+	assert.SliceNotContains(t, "c", input)
+
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContains(t, "c", input)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContains(t, 0, input)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.SliceNotContains(t, "a", input)
+	})
+}
+
+func TestSliceContainsAnyEmpty(t *testing.T) {
+	var emptyInput []any
+
+	assert.SliceNotContains(t, 0, emptyInput)
+	assert.SliceNotContains(t, -10, emptyInput)
+	assert.SliceNotContains(t, 100, emptyInput)
+	assert.SliceNotContains(t, "", emptyInput)
+	assert.SliceNotContains(t, "c", emptyInput)
+
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContains(t, "c", emptyInput)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContains(t, 0, emptyInput)
+	})
+}
+
+func TestSliceContainsAny(t *testing.T) {
+	input := []any{1, "a"}
+	result := assert.SliceContains(t, 1, input)
+	assert.Equals(t, result, 0)
+	result = assert.SliceContains(t, "a", input)
+	assert.Equals(t, result, 1)
+
+	assert.SliceNotContains(t, "b", input)
+	assert.SliceNotContains(t, 0, input)
+
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContains(t, 0, input)
+	})
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContains(t, "b", input)
+	})
+}
+
+type sliceTestObject struct {
+	a int
+	b string
+}
+
+func TestSliceContainsMatch(t *testing.T) {
+	testObj1 := sliceTestObject{1, "test1"}
+	testObj2 := sliceTestObject{2, "test2"}
+	testSlice := []sliceTestObject{testObj1, testObj2}
+
+	assert.SliceContainsMatch(t, func(value sliceTestObject) bool {
+		return value.a == 1
+	}, testSlice)
+	assert.SliceContainsMatch(t, func(value sliceTestObject) bool {
+		return value.a == 2
+	}, testSlice)
+	assert.SliceContainsMatch(t, func(value sliceTestObject) bool {
+		return value.b == "test1"
+	}, testSlice)
+
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContainsMatch(t, func(value sliceTestObject) bool {
+			return value.a == 0
+		}, testSlice)
+	})
+	testFailure(t, func(t *testing.T) {
+		// Test empty slice
+		assert.SliceContainsMatch(t, func(value sliceTestObject) bool {
+			return value.a == 1
+		}, []sliceTestObject{})
+	})
+}
+
+func TestSliceContainsExtractor(t *testing.T) {
+	testObj1 := sliceTestObject{1, "test1"}
+	testObj2 := sliceTestObject{2, "test2"}
+	testSlice := []sliceTestObject{testObj1, testObj2}
+
+	assert.SliceContainsExtractor(t, func(value sliceTestObject) int {
+		return value.a
+	}, 1, testSlice)
+	assert.SliceContainsExtractor(t, func(value sliceTestObject) int {
+		return value.a
+	}, 2, testSlice)
+	assert.SliceContainsExtractor(t, func(value sliceTestObject) string {
+		return value.b
+	}, "test1", testSlice)
+
+	testFailure(t, func(t *testing.T) {
+		assert.SliceContainsExtractor(t, func(value sliceTestObject) int {
+			return value.a
+		}, 0, testSlice)
+	})
+	testFailure(t, func(t *testing.T) {
+		// Test empty slice
+		assert.SliceContainsExtractor(t, func(value sliceTestObject) int {
+			return value.a
+		}, 1, []sliceTestObject{})
+	})
+}


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds several slice assertions:
- Assert that an item is in the list
- Assert that an item isn't in the list
- Assert that an item with a value associated with it is in the list. An extractor function is used to get the item
- Assert that an item that passes the passed in function is present in the list

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).