### PR TITLE
Upgrade Golang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,13 +67,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-<<<<<<< HEAD
           go-version: 1.21.6
       - uses: actions/cache@v4
-=======
-          go-version: 1.18
-      - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3
->>>>>>> main
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
         with:
-          version: v1.52.2
+          version: v1.55.2
   test:
     name: go test
     runs-on: ubuntu-latest
@@ -22,12 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Set up Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: 1.21.6
       - name: Set up gotestfmt
         uses: GoTestTools/gotestfmt-action@v2
-      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
@@ -65,10 +65,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Set up Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
-      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
+          go-version: 1.21.6
+      - uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.arcalot.io/assert
 
-go 1.18
+go 1.21


### PR DESCRIPTION
## Changes introduced with this PR

- [X] Upgrade package to use golang 1.21.
- [X] Upgrade CI golang and actions.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).