### PR TITLE
Added assertions to validate the value of a panic

### DIFF
--- a/panic.go
+++ b/panic.go
@@ -6,7 +6,7 @@ import "testing"
 // Does not detect panics in separate goroutines.
 func Panics(t *testing.T, functionToTest func()) {
 	defer func() {
-		// This deferred function will capture the panic if it panics
+		// This deferred function will capture the panic (if present) from the function under test.
 		if r := recover(); r == nil {
 			t.Fatalf("Expected function to panic, but it didn't.")
 		}
@@ -22,7 +22,7 @@ func Panics(t *testing.T, functionToTest func()) {
 // Does not detect panics in separate goroutines.
 func PanicsContains(t *testing.T, functionToTest func(), expectedErrMsg string) {
 	defer func() {
-		// This deferred function will capture the panic if it panics
+		// This deferred function will capture the panic (if present) from the function under test.
 		r := recover()
 		if r == nil {
 			t.Fatalf("Expected function to panic, but it didn't.")
@@ -51,7 +51,7 @@ func PanicsWithValidation(
 	validationFunction func(*testing.T, any),
 ) {
 	defer func() {
-		// This deferred function will capture the panic if it panics
+		// This deferred function will capture the panic (if present) from the function under test.
 		r := recover()
 		if r == nil {
 			t.Fatalf("Expected function to panic, but it didn't.")
@@ -67,7 +67,7 @@ func PanicsWithValidation(
 // Does not detect panics in separate goroutines.
 func NoPanic(t *testing.T, functionToTest func()) {
 	defer func() {
-		// This deferred function will capture the panic if it panics
+		// This deferred function will capture the panic (if present) from the function under test.
 		if r := recover(); r != nil {
 			t.Fatalf("Expected function to not panic, but it did. Panic output: %v", r)
 		}

--- a/panic.go
+++ b/panic.go
@@ -16,6 +16,53 @@ func Panics(t *testing.T, functionToTest func()) {
 	functionToTest()
 }
 
+// PanicsContains asserts that the function causes a panic.
+// It also asserts that the panic's error's string representation has
+// the given substring within it.
+// Does not detect panics in separate goroutines.
+func PanicsContains(t *testing.T, functionToTest func(), expectedErrMsg string) {
+	defer func() {
+		// This deferred function will recover it if it panics
+		r := recover()
+		if r == nil {
+			t.Fatalf("Expected function to panic, but it didn't.")
+		}
+		err, isErr := r.(error)
+		str, isStr := r.(string)
+		if !isErr && !isStr {
+			t.Fatalf("panic returned value that is neither a string nor an error; got %T", r)
+		}
+		if !isStr {
+			str = err.Error()
+		}
+		Contains(t, str, expectedErrMsg)
+	}()
+
+	// Run function to see if it panics.
+	functionToTest()
+}
+
+// PanicsWithValidation asserts that the function causes a panic.
+// It also calls the function passed in to allow validation of the panicked value.
+// Does not detect panics in separate goroutines.
+func PanicsWithValidation(
+	t *testing.T,
+	functionToTest func(),
+	validationFunction func(*testing.T, any),
+) {
+	defer func() {
+		// This deferred function will recover it if it panics
+		r := recover()
+		if r == nil {
+			t.Fatalf("Expected function to panic, but it didn't.")
+		}
+		validationFunction(t, r)
+	}()
+
+	// Run function to see if it panics.
+	functionToTest()
+}
+
 // NoPanic asserts that the function does not cause a panic.
 // Does not detect panics in separate goroutines.
 func NoPanic(t *testing.T, functionToTest func()) {

--- a/panic.go
+++ b/panic.go
@@ -6,7 +6,7 @@ import "testing"
 // Does not detect panics in separate goroutines.
 func Panics(t *testing.T, functionToTest func()) {
 	defer func() {
-		// This deferred function will recover it if it panics
+		// This deferred function will capture the panic if it panics
 		if r := recover(); r == nil {
 			t.Fatalf("Expected function to panic, but it didn't.")
 		}
@@ -22,7 +22,7 @@ func Panics(t *testing.T, functionToTest func()) {
 // Does not detect panics in separate goroutines.
 func PanicsContains(t *testing.T, functionToTest func(), expectedErrMsg string) {
 	defer func() {
-		// This deferred function will recover it if it panics
+		// This deferred function will capture the panic if it panics
 		r := recover()
 		if r == nil {
 			t.Fatalf("Expected function to panic, but it didn't.")
@@ -51,7 +51,7 @@ func PanicsWithValidation(
 	validationFunction func(*testing.T, any),
 ) {
 	defer func() {
-		// This deferred function will recover it if it panics
+		// This deferred function will capture the panic if it panics
 		r := recover()
 		if r == nil {
 			t.Fatalf("Expected function to panic, but it didn't.")
@@ -67,7 +67,7 @@ func PanicsWithValidation(
 // Does not detect panics in separate goroutines.
 func NoPanic(t *testing.T, functionToTest func()) {
 	defer func() {
-		// This deferred function will recover it if it panics
+		// This deferred function will capture the panic if it panics
 		if r := recover(); r != nil {
 			t.Fatalf("Expected function to not panic, but it did. Panic output: %v", r)
 		}

--- a/panic_test.go
+++ b/panic_test.go
@@ -1,6 +1,7 @@
 package assert_test
 
 import (
+	"fmt"
 	"testing"
 
 	"go.arcalot.io/assert"
@@ -10,15 +11,15 @@ func panicsTest() {
 	panic("This is for testing purposes")
 }
 
-func panicWithArgs(_ int, _ int) {
-	panic("This is for testing purposes")
+func panicWithArgs(panicValue any, _ int) {
+	panic(panicValue)
 }
 
 func TestCatchesPanic(t *testing.T) {
 	// Does panic
 	assert.Panics(t, panicsTest)
 	assert.Panics(t, func() {
-		panicWithArgs(0, 0)
+		panicWithArgs("This is for testing purposes", 0)
 	})
 	// Does not panic
 	testFailure(t, func(t *testing.T) {
@@ -39,5 +40,109 @@ func TestNoPanic(t *testing.T) {
 		assert.NoPanic(t, func() {
 			panicWithArgs(0, 0)
 		})
+	})
+}
+
+func TestCatchesPanicString(t *testing.T) {
+	// Does panic
+	// Test with string panic
+	assert.PanicsContains(
+		t,
+		func() {
+			panicWithArgs("This is for testing purposes", 0)
+		},
+		"testing purposes",
+	)
+	// Test with error panic
+	assert.PanicsContains(
+		t,
+		func() {
+			panicWithArgs(fmt.Errorf("this is for testing purposes"), 0)
+		},
+		"testing purposes",
+	)
+	// Panic value fails
+	// Test with string
+	testFailure(t, func(t *testing.T) {
+		assert.PanicsContains(
+			t,
+			func() {
+				panicWithArgs("This is for testing purposes", 0)
+			},
+			"wrong substr",
+		)
+	})
+	// Test with error
+	testFailure(t, func(t *testing.T) {
+		assert.PanicsContains(
+			t,
+			func() {
+				panicWithArgs(fmt.Errorf("this is for testing purposes"), 0)
+			},
+			"wrong substr",
+		)
+	})
+	// Test incompatible panic. PanicsContains expects a string or error type.
+	testFailure(t, func(t *testing.T) {
+		assert.PanicsContains(
+			t,
+			func() {
+				panicWithArgs(0, 0)
+			},
+			"abc",
+		)
+	})
+	// Does not panic
+	testFailure(t, func(t *testing.T) {
+		assert.PanicsContains(
+			t,
+			func() {},
+			"",
+		)
+	})
+}
+
+func TestCatchesPanicWithValidation(t *testing.T) {
+	// Does panic
+	// Test with int panic
+	assert.PanicsWithValidation(
+		t,
+		func() {
+			panicWithArgs(1, 0)
+		},
+		func(t *testing.T, panicValue any) {
+			assert.Equals(t, panicValue, 1)
+		},
+	)
+	// Test with string panic
+	assert.PanicsWithValidation(
+		t,
+		func() {
+			panicWithArgs("abc", 0)
+		},
+		func(t *testing.T, panicValue any) {
+			assert.Equals(t, panicValue, "abc")
+		},
+	)
+	// Panic's value validation fails
+	// Test with string
+	testFailure(t, func(t *testing.T) {
+		assert.PanicsWithValidation(
+			t,
+			func() {
+				panicWithArgs("This is for testing purposes", 0)
+			},
+			func(t *testing.T, panicValue any) {
+				assert.Equals(t, panicValue, "abc")
+			},
+		)
+	})
+	// Does not panic
+	testFailure(t, func(t *testing.T) {
+		assert.PanicsWithValidation(
+			t,
+			func() {},
+			func(t *testing.T, a any) {},
+		)
 	})
 }


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds assertions that make it easy to validate that a panic has the expected value. This is helpful when you ensure that the panic is the expected panic, which is important when there are multiple potential causes of panics.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).